### PR TITLE
feat: admin config knobs + shard totals + light visual fixes

### DIFF
--- a/controllers/admin/configController.js
+++ b/controllers/admin/configController.js
@@ -17,7 +17,7 @@ function cleanKeys(obj, existing = {}) {
     if (typeof newValue === 'object' && newValue !== null && !Array.isArray(newValue)) {
       cleaned[key] = cleanKeys(newValue, oldValue || {});
     } else if (
-      ['dbPort', 'intervalMinutes', 'accessRetentionDays'].includes(key) &&
+      ['dbPort', 'intervalMinutes', 'accessRetentionDays', 'accessLevelFilter', 'minBadges'].includes(key) &&
       typeof newValue === 'string' &&
       /^\d+$/.test(newValue)
     ) {

--- a/controllers/characterController.js
+++ b/controllers/characterController.js
@@ -286,6 +286,7 @@ async function showCharacter(req, res) {
           e.InfluencePoints,
           e.TotalTime,
           e.LoginCount,
+          e.AccessLevel,
           e.LastActive,
           e.TitleCommon,
           e.TitleOrigin,
@@ -405,6 +406,7 @@ async function showCharacter(req, res) {
       stringClean,
       portraitVersion,
       bgPath,
+      role: isAdmin ? 'admin' : 'user'
     });
 
   } catch (err) {

--- a/routes/admin/index.js
+++ b/routes/admin/index.js
@@ -5,6 +5,7 @@ const requireAdmin = require(global.BASE_DIR + '/middleware/requireAdmin');
 router.use('/', require('./dashboard'));
 router.use('/manifest', require('./manifest'));
 router.use('/users', require('./users'));
+router.use('/updateAccessLevel', require('./updateAccessLevel'));
 router.use('/news', require('./news'));
 router.use('/style', require('./style')); 
 router.use('/blacklist', require('./blacklist')); 

--- a/routes/admin/updateAccessLevel.js
+++ b/routes/admin/updateAccessLevel.js
@@ -1,0 +1,35 @@
+const express   = require('express');
+const sql       = require('mssql');
+const { getGamePool } = require(global.BASE_DIR + '/db');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const { serverKey, containerId, accessLevel } = req.body;
+    const lvl = Math.max(0, Math.min(11, Number(accessLevel)));
+
+    const pool = await getGamePool(serverKey);
+    await pool.request()
+      .input('lvl', sql.Int, lvl)
+      .input('cid', sql.Int, containerId)
+      .query(`
+        UPDATE dbo.Ents
+        SET    AccessLevel = @lvl
+        WHERE  ContainerId = @cid
+      `);
+
+    res.redirect('back');
+  } catch (err) {
+    console.error('[updateAccessLevel]', err);
+    res.redirect('back');
+  }
+});
+
+module.exports = router;
+
+// Add this for route metadata
+module.exports.meta = { 
+  access : ['admin'], 
+  display: false 
+};

--- a/utils/ensureConfig.mjs
+++ b/utils/ensureConfig.mjs
@@ -158,8 +158,11 @@ async function runSetupWizard() {
     siteName: answers.siteName,
     domain: answers.domain,
     ipAddr: answers.ipAddr,
-	useAutoEncrypt: answers.useAutoEncrypt,
+    useAutoEncrypt: answers.useAutoEncrypt,
     session_secret: sessionSecret,
+    accessLevelFilter: 0,
+    minBadges: 500,
+    quantizeBirthDate: 'day',
     email: {
       provider: '',
       fromEmail: '',

--- a/views/admin/config_editor.ejs
+++ b/views/admin/config_editor.ejs
@@ -45,6 +45,32 @@
             </button>
         </div>
       </div>
+      <div>
+        <label class="block text-sm font-medium">Access Level Filter (0 - 11)</label>
+          <input type="number"
+            name="config[accessLevelFilter]"
+            min="0" max="11" step="1"
+            value="<%= config.accessLevelFilter ?? 0 %>"
+            class="input" />
+        <p class="text-xs text-gray-500">
+        Characters above this Access Level will not be included in site stats.
+        </p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium">Minimum Badges for Spotlight (0 - 500)</label>
+          <input type="number"
+            name="config[minBadges]"
+            min="0" max="500" step="10"
+            value="<%= config.minBadges ?? 500 %>"
+            class="input" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium">Character Birthday Granularity</label>
+        <select name="config[quantizeBirthDate]" class="input">
+          <option value="day"   <%= config.quantizeBirthDate === 'day'   ? 'selected' : '' %>>Exact Day</option>
+          <option value="month" <%= config.quantizeBirthDate === 'month' ? 'selected' : '' %>>Whole Month</option>
+        </select>
+      </div>
     </div>
 
     <h2 class="text-xl font-semibold mb-2">Auth DB</h2>

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -19,7 +19,7 @@
 
 <p class="mb-6 text-gray-300">Welcome<% if (user) { %>, <strong class="text-white"><%= user.username %></strong><% } %>.</p>
 
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+<div class="grid grid-cols-1 xl:grid-cols-2 2xl:grid-cols-3 gap-4 mb-8">
 
   <% if (links && links.length) { %>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -79,6 +79,12 @@
             </span>
           </td>
             <td class="px-2 py-2 border-b border-gray-700 space-x-1">
+              <!-- Manage Characters Action -->
+              <button type="button"
+                class="bg-blue-600 hover:bg-blue-700 text-white text-xs px-2 py-1 rounded"
+                onclick="location.href='/account/characters?uid=<%= user.uid %>'">
+                Manage
+              </button>
               <!-- Ban/Unban/Confirm Action -->
               <button type="button"
                 data-form-action="/admin/users/<%= user.uid %>/ban"

--- a/views/character.ejs
+++ b/views/character.ejs
@@ -29,6 +29,9 @@
 			</form>
 		  </div>
 		<% } %>
+		
+		<br>
+		
 		<div style="display: flex;
 		justify-content: center;
 		background-image: url('/<%= bgPath %>');
@@ -83,12 +86,31 @@
             (Unknown)
           <% } %>
         </li>
+        <li><strong>Access Level:</strong>
+          <% if (role === 'admin') { %>
+            <form action="/admin/updateAccessLevel" method="post" style="display:inline;">
+              <input type="hidden" name="serverKey"   value="<%= serverKey %>">
+              <input type="hidden" name="containerId" value="<%= character.ContainerId %>">
+              <select name="accessLevel"
+                onchange="this.form.submit()"
+                style="background:#222;color:#fff;">
+                <% for (let i = 0; i <= 11; i++) { %>
+                  <option value="<%= i %>" <%= character.AccessLevel === i ? 'selected' : '' %>>
+                    <%= i %>
+                  </option>
+                <% } %>
+              </select>
+            </form>
+          <% } else { %>
+            <%= character.AccessLevel ?? 0 %>
+          <% } %>
+        </li>
       </ul>
     </div>
 
     <!-- Right Column: Character Name, Bio, and Badges -->
     <div class="right-panel" style="flex: 1; max-width: 720px;">
-      <h1 style="margin-top: 0;"><%= stringClean(character.Name) %></h1>
+	  <h1 class="text-3xl font-bold mb-4"><%= stringClean(character.Name) %></h1>
       <p><strong>Player:</strong> @<%= stringClean(character.globalHandle) %></p>
 
       <div style="margin: 12px 0;">
@@ -96,7 +118,7 @@
         <p style="white-space: pre-wrap;"><%- stringClean(character.Description) %></p>
       </div>
 
-      <h2>Badge Tracking</h2>
+	  <h2 class="text-xl font-bold mb-2">Badge Tracking</h2>
       <div style="margin: 24px 0;">
         <div style="background: #ccc; border-radius: 4px; height: 12px; overflow: hidden;">
           <div style="background: linear-gradient(to right, orange, gold); width: <%= Math.floor((ownedBadges / totalBadges) * 100) %>%; height: 100%;"></div>
@@ -107,7 +129,7 @@
       </div>
 
       <% badgeCategoryList.forEach(category => { %>
-        <h3><%= category.name %></h3>
+        <h3 class="text-lg font-semibold"><%= category.name %></h3>
         <div style="margin-bottom: 8px;">
           <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px;">
             <div style="flex: 1; background: #ccc; height: 16px; border-radius: 4px; margin-right: 8px;">
@@ -123,10 +145,12 @@
           <li class="loading-spinner">Loading...</li>
         </ul>
       <% }) %>
-
-      <h2>Unearned but Eligible Badges</h2>
+      
+      <br>
+      
+      <h2 class="text-xl font-bold mb-2">Unearned but Eligible Badges</h2>
       <% unearnedBadgeCategories.forEach(category => { %>
-        <h3><%= category.name %></h3>
+        <h3 class="text-lg font-semibold"><%= category.name %></h3>
         <div style="margin-bottom: 8px;">
           <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px;">
             <div style="flex: 1; background: #ccc; height: 16px; border-radius: 4px; margin-right: 8px;">

--- a/views/character_list.ejs
+++ b/views/character_list.ejs
@@ -1,5 +1,25 @@
 <% Object.entries(charactersByServer).forEach(([serverKey, characters]) => { %>
   <h2 style="margin-top: 24px; font-size: 20px; color: #eee;"><%= serverKey.toUpperCase() %></h2>
+
+  <!-- Toggle Details -->
+  <a href="javascript:void(0)"
+     onclick="document.getElementById('stats-<%= serverKey %>').classList.toggle('hidden')"
+     style="display: inline-block; font-size: 14px; color:#eee; margin: 2px 0 8px;">
+    Toggle Details
+  </a>
+
+  <!-- Shard Stats Wrapper (hidden until toggled) -->
+  <% const t = totalsByServer && totalsByServer[serverKey] ? totalsByServer[serverKey] : null; %>
+  <% if (t) { %>
+    <div id="stats-<%= serverKey %>"
+         class="hidden flex flex-wrap"
+         style="font-size: 14px; color: #ccc; gap: 2rem; margin: 4px 0 12px;">
+      <div><strong>Characters: </strong><%= t.totalCharacters.toLocaleString() %></div>
+      <div><strong>Logins: </strong><%= t.totalLogins.toLocaleString() %></div>
+      <div><strong>Hours Played: </strong><%= t.totalHours.toLocaleString() %></div>
+    </div>
+  <% } %>
+  
   <div class="character-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 16px;">
     <% characters.forEach(character => { %>
 		<div class="character-card"


### PR DESCRIPTION
**[FEATURE: Config-Birthdate]**
Added a control knob to the admin config editor page so server owners can select day- or month-level granularity for character birth dates. Month may be better for small server owners, otherwise the widget is often empty. Default is 'day' which preserves legacy behavior.

_Files modified:_
- `/services/homeWidgets.js`: Adjusted the queries based on the setting; sorts by DateCreated day then LastActive day.
- `/utils/ensureConfig.mjs`:  Places the quantizeBirthDate key with a default of 'day' when creating config.json.
- `/views/admin/config_editor.ejs`: Exposed the setting control (Character Birthday Granularity).
<br>

**[FEATURE: Config-accessLevelFilter]**
Replaced hardcoded Access Level limit of 0 for site stat quries with a parameterized configurable value. Allows admins to specify Access Level Filter on the config_editor page. Characters above that level will not be included in main page widget stats. Default is 0 which preserves legacy behavior.

_Files modified:_
 - `/controllers/admin/configController.js`: Added accessLevelFilter to cleanKeys() to practice safe json-ing.
 - `/services/homeWidgets.js`: Modified each query to consult config.accessLevelFilter (parameterized as @maxAccess).
 - `/utils/ensureConfig.mjs`: Places the accessLevelFilter key with a default of 0 when creating config.json.
 - `/views/admin/config_editor.ejs`: Exposted the setting control (Access Level Filter).
<br>

**[FEATURE: Config-minBadges]**
Added a control knob to the admin config editor page so server owners can select any value from 0 to 500 as a minimum badge threshold for the Spotlight. Control uses increments of 10. Default is 500 to preserve legacy behavior.

_Files modified:_
 - `/controllers/admin/configController.js`: Added minBadges to cleanKeys() to practice safe json-ing.
 - `/services/homeWidgets.js`: Check badges.length against config.minBadges instead of 500.
 - `/utils/ensureConfig.mjs`: Places the minBadges key with a default of 500 when creating config.json.
 - `/views/admin/config_editor.ejs`: Exposed the setting control (Minimum Badges for Spotlight).
<br>

**[FEATURE: Set-AccessLevel]**	
Added an Access Level Dropdown control visible only to admins on the individual Character page. Update query runs as soon as a new one is selected, no need to "save".

_Files modified:_
 - `/controllers/characterController.js`: Added e.AccessLevel field to the SELECT query so it is pulled into const charResult.
 - `/routes/admin/updateAccessLevel.js`: New route file created to handle updating Access Level in the db (matching on ContainerId of the character).
 - `/routes/admin/index.js`: Added router use/require line for the new updateAccessLevel.js file.
 - `/views/character.ejs`: Exposed the setting control (Access Level) if user role is 'admin'.
<br>

**[FEATURE: Manage-Button]**
Add a "Manage" button to the User Management page. Clicking this allows an admin to visit that user's character list temporarily; selecting one of their characters exposes admin controls like Access Level (and possibly others in the future - rename? delete? export?). Browsing to any other page (like the character list) returns to your own characters.

_Files modified:_
 - `/controllers/account/characterListController.js`: Added user role verification and a check for an override uid appended to the url.
 - `/views/admin/users.ejs`: Exposed the Manage button next to the Ban button.
<br>

**[FEATURE: Shard-Totals]**
Added a Toggle Details link under the shard name on the Character List page (basically stolen from your badge detail functionality on the character page) which hides/unhides total # of characters, character logins, and cumulative hours played for that shard.

_Files modified:_
 - `/controllers/characterListController.js`: Get total # of characters, logins, and hours played; stored in totalsByServer.
 - `/views/character_list.ejs`: Added the Toggle Details link and the details wrapper to be displayed/hidden beneath the shard name.
<br>

**[BUGFIX: CharacterPage-TextSize]**
All text on the character.ejs view was appearing the same size regardless of header tag level (h1, h2, h3). Replaced each header tag with ones that use tailwind classes as used on other pages. Other minor tweaks to this page: added a \<br\> between the "Clear Render/Delete Portrait" buttons and the portrait itself, as they were touching the upper edge of the image. Also added a \<br\> before the Unearned but Elligible badges section to make the split between sections clearer.

_Files modified:_
 - `/views/character.ejs`
<br>

**[BUGFIX: Dashboard-Grid]**
Modified the responsive grid breakpoints to prevent over-deformation of the tiles that display the admin links. Tested to ensure it was still making sensible column-count decisions whil resizing the window. Inner grid uses sm: and lg: while outer grid (which previously matched) has been increased to xl: and 2xl: but maintains a max of 3 columns. Results: maximized at 4k resolution will notice no change; smaller windows will have cleaner buttons with no text overflowing the tiles.

_Files modified:_
 - `/views/admin/dashboard.ejs`